### PR TITLE
(fix|feature): Fixed bug with camera project method and added python bindings

### DIFF
--- a/calico/calico.cpp
+++ b/calico/calico.cpp
@@ -267,7 +267,18 @@ PYBIND11_MODULE(_calico, m) {
                  std::string("Error: ") + std::string(status.message()));
            }
          })
-    .def("SetMeasurementNoise", &Camera::SetMeasurementNoise);
+    .def("SetMeasurementNoise", &Camera::SetMeasurementNoise)
+    .def("Project",
+         [](const Camera& self, const std::vector<double>& interp_times,
+            const Trajectory& sensorrig_trajectory, const WorldModel& world_model) {
+           const auto interp_vals = self.Project(
+               interp_times, sensorrig_trajectory, world_model);
+           if (!interp_vals.status().ok()) {
+             throw std::runtime_error(
+                 std::string("Error: ") + std::string(interp_vals.status().message()));
+           }
+           return interp_vals.value();
+         });
 
   // Trajectory class.
   py::class_<Trajectory, std::shared_ptr<Trajectory>>(m, "Trajectory")

--- a/calico/sensors/camera.cpp
+++ b/calico/sensors/camera.cpp
@@ -188,6 +188,9 @@ absl::StatusOr<std::vector<CameraMeasurement>> Camera::Project(
           T_camera_world * rigidbody.T_world_rigidbody;
       for (const auto& [point_id, point] : rigidbody.model_definition) {
         const Eigen::Vector3d point_camera = T_camera_rigidbody * point;
+        if (point_camera.z() <= 0) {
+          continue;
+        }
         const absl::StatusOr<Eigen::Vector2d> projection =
           camera_model_->ProjectPoint(intrinsics_, point_camera);
         measurements.push_back({


### PR DESCRIPTION
RigidBody projections were not being handled properly as points behind the camera caused the method to return an error. A better behavior is to simply create projections for the points that are in front of the camera and skip all others.

This method is also now exposed in the Python bindings.