### PR TITLE
feat: Refactored WorldModel class to modify RigidBody and Landmark objects in-place in Python.

### DIFF
--- a/calico/batch_optimizer.cpp
+++ b/calico/batch_optimizer.cpp
@@ -18,7 +18,7 @@ ceres::Solver::Options DefaultSolverOptions() {
 
 BatchOptimizer::~BatchOptimizer() {
   // If we don't own an object, release the pointer so it doesn't get
-  // de-allocated it.
+  // de-allocated.
   for (int i = 0; i < sensors_.size(); ++i) {
     if (!own_sensors_[i]) {
       sensors_.at(i).release();

--- a/calico/test/batch_optimizer_test.cpp
+++ b/calico/test/batch_optimizer_test.cpp
@@ -40,7 +40,7 @@ TEST_F(BatchOptimizerTest, ToyStereoCameraAndImuCalibration) {
   }
   WorldModel* world_model = new WorldModel;
   const Eigen::Vector3d true_gravity = world_model->gravity();
-  EXPECT_OK(world_model->AddRigidBody(planar_target));
+  EXPECT_OK(world_model->AddRigidBody(&planar_target, /*take_ownership=*/false));
   // Construct the sensorrig trajectory.
   Trajectory* trajectory_world_sensorrig = new Trajectory;
   ASSERT_OK(trajectory_world_sensorrig->FitSpline(poses_world_sensorrig));

--- a/calico/test/camera_test.cpp
+++ b/calico/test/camera_test.cpp
@@ -122,7 +122,7 @@ TEST(CameraProjectionTest, LandmarkInView) {
   // Construct a landmark placed at the origin.
   Landmark landmark;
   WorldModel world_model;
-  ASSERT_OK(world_model.AddLandmark(landmark));
+  ASSERT_OK(world_model.AddLandmark(&landmark, /*take_ownership=*/false));
   // Construct the camera.
   Camera camera;
   ASSERT_OK(camera.SetModel(CameraIntrinsicsModel::kOpenCv5));
@@ -148,9 +148,9 @@ TEST(CameraProjectionTest, LandmarkOutOfView) {
     {1.0, Pose3d(q_world_camera, t_world_camera)},
   }));
   // Construct a landmark placed behind the camera.
-  const Landmark landmark{.point = Eigen::Vector3d(0.0, 0.0, 2.0)};
+  Landmark landmark{.point = Eigen::Vector3d(0.0, 0.0, 2.0)};
   WorldModel world_model;
-  ASSERT_OK(world_model.AddLandmark(landmark));
+  ASSERT_OK(world_model.AddLandmark(&landmark, /*take_ownership=*/false));
   // Construct the camera.
   Camera camera;
   ASSERT_OK(camera.SetModel(CameraIntrinsicsModel::kOpenCv5));
@@ -175,7 +175,7 @@ TEST(CameraProjectionTest, RigidBodyInView) {
     {1.0, Pose3d(q_world_camera, t_world_camera)},
   }));
   // Construct a rigidbody placed at the origin.
-  const RigidBody rigidbody {
+  RigidBody rigidbody {
     .model_definition = {
       {0, Eigen::Vector3d(-0.5, -0.5, 0.0)},
       {1, Eigen::Vector3d(-0.5, 0.5, 0.0)},
@@ -185,7 +185,7 @@ TEST(CameraProjectionTest, RigidBodyInView) {
     .id = 0
   };
   WorldModel world_model;
-  ASSERT_OK(world_model.AddRigidBody(rigidbody));
+  ASSERT_OK(world_model.AddRigidBody(&rigidbody, /*take_ownership=*/false));
   // Construct the camera.
   Camera camera;
   ASSERT_OK(camera.SetModel(CameraIntrinsicsModel::kOpenCv5));
@@ -210,7 +210,7 @@ TEST(CameraProjectionTest, RigidBodyOutOfView) {
     {1.0, Pose3d(q_world_camera, t_world_camera)},
   }));
   // Construct a rigidbody placed at the origin.
-  const RigidBody rigidbody {
+  RigidBody rigidbody {
     .model_definition = {
       {0, Eigen::Vector3d(-0.5, -0.5, 0.0)},
       {1, Eigen::Vector3d(-0.5, 0.5, 0.0)},
@@ -221,7 +221,7 @@ TEST(CameraProjectionTest, RigidBodyOutOfView) {
     .id = 0
   };
   WorldModel world_model;
-  ASSERT_OK(world_model.AddRigidBody(rigidbody));
+  ASSERT_OK(world_model.AddRigidBody(&rigidbody, /*take_ownership=*/false));
   // Construct the camera.
   Camera camera;
   ASSERT_OK(camera.SetModel(CameraIntrinsicsModel::kOpenCv5));

--- a/calico/test/world_model_test.cpp
+++ b/calico/test/world_model_test.cpp
@@ -16,38 +16,38 @@ using ::testing::SizeIs;
 
 class WorldModelTest : public ::testing::Test {
  protected:
-  const absl::flat_hash_map<int, Landmark> expected_landmarks {
+  absl::flat_hash_map<int, Landmark> expected_landmarks {
     {0, Landmark{
-        .point = Eigen::Vector3d::Random(),
-        .id = 0,
-      },
+          .point = Eigen::Vector3d::Random(),
+          .id = 0,
+        },
     },
     {1, Landmark{
-        .point = Eigen::Vector3d::Random(),
-        .id = 1,
-      },
+          .point = Eigen::Vector3d::Random(),
+          .id = 1,
+        },
     },
   };
-  const absl::flat_hash_map<int, RigidBody> expected_rigidbodies {
-    {0, RigidBody {
-        .model_definition = {
-          {0, Eigen::Vector3d::Random()},
-          {1, Eigen::Vector3d::Random()}
+  absl::flat_hash_map<int, RigidBody> expected_rigidbodies {
+    {0, RigidBody{
+          .model_definition = {
+            {0, Eigen::Vector3d::Random()},
+            {1, Eigen::Vector3d::Random()}
+          },
+          .T_world_rigidbody = Pose3d(Eigen::Quaterniond::UnitRandom(),
+                                      Eigen::Vector3d::Random()),
+          .id = 0
         },
-        .T_world_rigidbody = Pose3d(Eigen::Quaterniond::UnitRandom(),
-                                    Eigen::Vector3d::Random()),
-        .id = 0
-      }
     },
-    {1, RigidBody {
-        .model_definition = {
-          {2, Eigen::Vector3d::Random()},
-          {3, Eigen::Vector3d::Random()}
+    {1, RigidBody{
+          .model_definition = {
+            {2, Eigen::Vector3d::Random()},
+            {3, Eigen::Vector3d::Random()}
+          },
+          .T_world_rigidbody = Pose3d(Eigen::Quaterniond::UnitRandom(),
+                                      Eigen::Vector3d::Random()),
+          .id = 1
         },
-        .T_world_rigidbody = Pose3d(Eigen::Quaterniond::UnitRandom(),
-                                    Eigen::Vector3d::Random()),
-        .id = 1
-      }
     },
   };
 
@@ -56,56 +56,54 @@ class WorldModelTest : public ::testing::Test {
 
 TEST_F(WorldModelTest, RigidBodyAccessors) {
   world_model_.ClearRigidBodies();
-  world_model_.rigidbodies() = expected_rigidbodies;
-  const absl::flat_hash_map<int, RigidBody> actual_rigidbodies =
-    world_model_.rigidbodies();
-  // TODO(yangjames): Write a matcher for this.
-  ASSERT_THAT(actual_rigidbodies, SizeIs(expected_rigidbodies.size()));
-  for (const auto& [rigidbody_id, expected_rigidbody] : expected_rigidbodies) {
-    ASSERT_THAT(actual_rigidbodies, Contains(Key(rigidbody_id)));
-    const RigidBody& actual_rigidbody = actual_rigidbodies.at(rigidbody_id);
-    EXPECT_THAT(actual_rigidbody.model_definition,
-                SizeIs(expected_rigidbody.model_definition.size()));
+  for (auto& [rigidbody_id, rigidbody] : expected_rigidbodies) {
+    ASSERT_OK(world_model_.AddRigidBody(&rigidbody, /*take_ownership=*/false));
+  }
 
-    for (const auto& [feature_id, expected_point] :
-           expected_rigidbody.model_definition) {
-      ASSERT_THAT(actual_rigidbody.model_definition, Contains(Key(feature_id)));
-      const Eigen::Vector3d& actual_point =
-        actual_rigidbody.model_definition.at(feature_id);
-      EXPECT_TRUE(actual_point.isApprox(expected_point));
+  // Check that all assigned memory and values are the same.
+  for (const auto& [rigidbody_id, actual_rigidbody] : expected_rigidbodies) {
+    const auto& actual_model_definition = actual_rigidbody.model_definition;
+    const auto& rigidbody = world_model_.rigidbodies().at(rigidbody_id);
+    const auto& model_definition = rigidbody->model_definition;
+    for (const auto& [feature_id, point] : model_definition) {
+      // Compare point.
+      const Eigen::Vector3d& actual_point = actual_model_definition.at(feature_id);
+      EXPECT_EQ(point.data(), actual_point.data());
+      EXPECT_TRUE(point.isApprox(actual_point));
+      // Compare pose.
+      EXPECT_TRUE(rigidbody->T_world_rigidbody.isApprox(actual_rigidbody.T_world_rigidbody));
+      EXPECT_EQ(
+        rigidbody->T_world_rigidbody.translation().data(),
+        actual_rigidbody.T_world_rigidbody.translation().data()
+      );
+      EXPECT_EQ(
+        rigidbody->T_world_rigidbody.rotation().coeffs().data(),
+        actual_rigidbody.T_world_rigidbody.rotation().coeffs().data()
+      );
     }
-    EXPECT_TRUE(actual_rigidbody.T_world_rigidbody
-                .isApprox(expected_rigidbody.T_world_rigidbody));
-    EXPECT_EQ(rigidbody_id, actual_rigidbody.id);
-    EXPECT_EQ(actual_rigidbody.id, expected_rigidbody.id);
-    EXPECT_EQ(actual_rigidbody.world_pose_is_constant,
-              expected_rigidbody.world_pose_is_constant);
-    EXPECT_EQ(actual_rigidbody.model_definition_is_constant,
-              expected_rigidbody.model_definition_is_constant);
   }
 }
 
 TEST_F(WorldModelTest, LandMarkAccessors) {
   world_model_.ClearLandmarks();
-  world_model_.landmarks() = expected_landmarks;
-  const absl::flat_hash_map<int, Landmark> actual_landmarks =
-    world_model_.landmarks();
-  // TODO(yangjames): Write a matcher for this.
-  ASSERT_THAT(actual_landmarks, SizeIs(expected_landmarks.size()));
-  for (const auto& [landmark_id, expected_landmark] : expected_landmarks) {
-    ASSERT_THAT(actual_landmarks, Contains(Key(landmark_id)));
-    const auto& actual_landmark = actual_landmarks.at(landmark_id);
-    EXPECT_TRUE(actual_landmark.point.isApprox(expected_landmark.point));
-    EXPECT_EQ(actual_landmark.id, expected_landmark.id);
-    EXPECT_EQ(actual_landmark.point_is_constant,
-              expected_landmark.point_is_constant);
+  for (auto& [landmark_id, landmark] : expected_landmarks) {
+    ASSERT_OK(world_model_.AddLandmark(&landmark, /*take_ownership=*/false));
+  }
+  for (const auto& [landmark_id, actual_landmark] : expected_landmarks) {
+    const auto& landmark = world_model_.landmarks().at(landmark_id);
+    const Eigen::Vector3d& actual_point = actual_landmark.point;
+    const Eigen::Vector3d& point = landmark->point;
+    EXPECT_EQ(point.data(), actual_point.data());
+    EXPECT_TRUE(point.isApprox(actual_point));
+    EXPECT_EQ(landmark->id, actual_landmark.id);
+    EXPECT_EQ(landmark->point_is_constant, actual_landmark.point_is_constant);
   }
 }
 
 TEST_F(WorldModelTest, AddLandmark) {
   world_model_.ClearLandmarks();
   EXPECT_EQ(world_model_.NumberOfLandmarks(), 0);
-  const Landmark landmark{};
+  Landmark* landmark = new Landmark;
   EXPECT_OK(world_model_.AddLandmark(landmark));
   EXPECT_EQ(world_model_.NumberOfLandmarks(), 1);
   EXPECT_EQ(world_model_.AddLandmark(landmark).code(),
@@ -116,7 +114,7 @@ TEST_F(WorldModelTest, AddLandmark) {
 TEST_F(WorldModelTest, AddRigidBody) {
   world_model_.ClearRigidBodies();
   EXPECT_EQ(world_model_.NumberOfRigidBodies(), 0);
-  const RigidBody rigidbody{};
+  RigidBody* rigidbody = new RigidBody;
   EXPECT_OK(world_model_.AddRigidBody(rigidbody));
   EXPECT_EQ(world_model_.NumberOfRigidBodies(), 1);
   EXPECT_EQ(world_model_.AddRigidBody(rigidbody).code(),
@@ -133,26 +131,30 @@ TEST_F(WorldModelTest, SetGravity) {
 TEST_F(WorldModelTest, AddParametersToProblem) {
   ceres::Problem problem;
   world_model_.Clear();
-  world_model_.rigidbodies() = expected_rigidbodies;
-  world_model_.landmarks() = expected_landmarks;
+  for (auto& [rigidbody_id, rigidbody] : expected_rigidbodies) {
+    ASSERT_OK(world_model_.AddRigidBody(&rigidbody, /*take_ownership=*/false));
+  }
+  for (auto& [landmark_id, landmark] : expected_landmarks) {
+    ASSERT_OK(world_model_.AddLandmark(&landmark, /*take_ownership=*/false));
+  }
   const int num_parameters_added = world_model_.AddParametersToProblem(problem);
   EXPECT_GT(problem.NumParameters(), 0);
   EXPECT_EQ(num_parameters_added, problem.NumParameters());
   for (const auto& [landmark_id, _] : expected_landmarks) {
-    Landmark& landmark = world_model_.landmarks().at(landmark_id);
-    EXPECT_TRUE(problem.HasParameterBlock(landmark.point.data()));
+    const std::unique_ptr<Landmark>& landmark = world_model_.landmarks().at(landmark_id);
+    EXPECT_TRUE(problem.HasParameterBlock(landmark->point.data()));
   }
   for (const auto& [rigidbody_id, _] : expected_rigidbodies) {
-    RigidBody& rigidbody = world_model_.rigidbodies().at(rigidbody_id);
-    for (const auto& [feature_id, point] : rigidbody.model_definition) {
+    const std::unique_ptr<RigidBody>& rigidbody = world_model_.rigidbodies().at(rigidbody_id);
+    for (const auto& [feature_id, point] : rigidbody->model_definition) {
       EXPECT_TRUE(problem.HasParameterBlock(point.data()));
     }
     EXPECT_TRUE(
         problem.HasParameterBlock(
-            rigidbody.T_world_rigidbody.rotation().coeffs().data()));
+            rigidbody->T_world_rigidbody.rotation().coeffs().data()));
     EXPECT_TRUE(
         problem.HasParameterBlock(
-            rigidbody.T_world_rigidbody.translation().data()));
+            rigidbody->T_world_rigidbody.translation().data()));
   }
 }
 


### PR DESCRIPTION
This delta refactors the `WorldModel` class so that it takes in `RigidBody` and `Landmark` pointers so that they can be treated like `Sensor` objects in Python where their optimization parameters are modified in-place in memory. When users run an optimization, they can access the initialized `RigidBody` and `Landmark` objects directly to get the optimized results.